### PR TITLE
Bumping up to 4.7.6

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -1,6 +1,6 @@
 ### UNIFI ###
 _build_unifi() {
-local VERSION="4.7.6"
+local VERSION="4.8.5-9bc3d72a"
 local FOLDER="UniFi"
 local FILE="${FOLDER}.unix.zip"
 local URL="http://www.ubnt.com/downloads/unifi/${VERSION}/${FILE}"

--- a/app.sh
+++ b/app.sh
@@ -1,6 +1,6 @@
 ### UNIFI ###
 _build_unifi() {
-local VERSION="4.8.5-9bc3d72a"
+local VERSION="4.8.7-95ca1b49"
 local FOLDER="UniFi"
 local FILE="${FOLDER}.unix.zip"
 local URL="http://www.ubnt.com/downloads/unifi/${VERSION}/${FILE}"

--- a/app.sh
+++ b/app.sh
@@ -1,6 +1,6 @@
 ### UNIFI ###
 _build_unifi() {
-local VERSION="4.9.1-691f5a97"
+local VERSION="5.0.3-f92cb0fc"
 local FOLDER="UniFi"
 local FILE="${FOLDER}.unix.zip"
 local URL="http://www.ubnt.com/downloads/unifi/${VERSION}/${FILE}"

--- a/app.sh
+++ b/app.sh
@@ -1,6 +1,6 @@
 ### UNIFI ###
 _build_unifi() {
-local VERSION="4.7.6"
+local VERSION="4.9.1"
 local FOLDER="UniFi"
 local FILE="${FOLDER}.unix.zip"
 local URL="http://www.ubnt.com/downloads/unifi/${VERSION}/${FILE}"

--- a/app.sh
+++ b/app.sh
@@ -1,6 +1,6 @@
 ### UNIFI ###
 _build_unifi() {
-local VERSION="4.7.6"
+local VERSION="4.9.1-691f5a97"
 local FOLDER="UniFi"
 local FILE="${FOLDER}.unix.zip"
 local URL="http://www.ubnt.com/downloads/unifi/${VERSION}/${FILE}"

--- a/app.sh
+++ b/app.sh
@@ -12,7 +12,7 @@ unzip "download/${VERSION}/${FILE}" -d "${PWD}/target"
 mkdir -p "${DEST}/data"
 cp -vafr "target/${FOLDER}/"* "${DEST}/"
 }
-
+###
 ### MONGODB ###
 _build_mongodb() {
 local VERSION="3.0.2"

--- a/app.sh
+++ b/app.sh
@@ -1,6 +1,6 @@
 ### UNIFI ###
 _build_unifi() {
-local VERSION="4.7.5"
+local VERSION="4.7.6"
 local FOLDER="UniFi"
 local FILE="${FOLDER}.unix.zip"
 local URL="http://www.ubnt.com/downloads/unifi/${VERSION}/${FILE}"

--- a/src/dest/service.sh
+++ b/src/dest/service.sh
@@ -7,7 +7,7 @@
 
 framework_version="2.1"
 name="unifi"
-version="4.7.6"
+version="4.9.1"
 description="UniFi AP Controller"
 depends="java8"
 webui=":8043/"

--- a/src/dest/service.sh
+++ b/src/dest/service.sh
@@ -4,10 +4,10 @@
 
 # import DroboApps framework functions
 . /etc/service.subr
-#http://www.ubnt.com/downloads/unifi/4.8.5-9bc3d72a/UniFi.unix.zip
+#http://www.ubnt.com/downloads/unifi/4.8.7-95ca1b49/UniFi.unix.zip
 framework_version="2.1"
 name="unifi"
-version="4.8.5-9bc3d72a"
+version="4.8.7-95ca1b49"
 description="UniFi AP Controller - Beta"
 depends="java8"
 webui=":8043/"

--- a/src/dest/service.sh
+++ b/src/dest/service.sh
@@ -7,7 +7,7 @@
 
 framework_version="2.1"
 name="unifi"
-version="4.7.6"
+version="4.9.1-691f5a97"
 description="UniFi AP Controller"
 depends="java8"
 webui=":8043/"

--- a/src/dest/service.sh
+++ b/src/dest/service.sh
@@ -4,11 +4,11 @@
 
 # import DroboApps framework functions
 . /etc/service.subr
-
+#http://www.ubnt.com/downloads/unifi/4.8.5-9bc3d72a/UniFi.unix.zip
 framework_version="2.1"
 name="unifi"
-version="4.7.6"
-description="UniFi AP Controller"
+version="4.8.5-9bc3d72a"
+description="UniFi AP Controller - Beta"
 depends="java8"
 webui=":8043/"
 

--- a/src/dest/service.sh
+++ b/src/dest/service.sh
@@ -7,7 +7,7 @@
 
 framework_version="2.1"
 name="unifi"
-version="4.9.1-691f5a97"
+version="5.0.3-f92cb0fc"
 description="UniFi AP Controller"
 depends="java8"
 webui=":8043/"

--- a/src/dest/service.sh
+++ b/src/dest/service.sh
@@ -4,7 +4,7 @@
 
 # import DroboApps framework functions
 . /etc/service.subr
-
+###
 framework_version="2.1"
 name="unifi"
 version="5.0.3-f92cb0fc"

--- a/src/dest/service.sh
+++ b/src/dest/service.sh
@@ -7,7 +7,7 @@
 
 framework_version="2.1"
 name="unifi"
-version="4.7.5"
+version="4.7.6"
 description="UniFi AP Controller"
 depends="java8"
 webui=":8043/"


### PR DESCRIPTION
Hi - ubnt put out a hotfix release for the unifi software to 4.7.6 for some incompatibility problems and security issues. : https://community.ubnt.com/t5/UniFi-Updates-Blog/UniFi-4-7-6-hotfix-release/ba-p/1390700

It appears they have also pulled the download for 4.7.5 (even tho it shows up on the site, you cant download it, 404) 

This just bumps things up to the newest version - tested on a drobo 5n

Will note I had to do a clean install when i came from 3.2.10. I didn't try to restore settings from backup, but taking a back up of the settings might save users some time. 
